### PR TITLE
Match 6.6.0.0 branch

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -4,9 +4,10 @@
     "description": "Shopware 6 conflicting packages",
     "license": "MIT",
     "require": {
-        "shopware/core": ">=6.5.0"
+        "shopware/core": "*"
     },
     "conflict": {
+        "shopware/core": "<6.5",
         "symfony/var-exporter": "v6.3.9 || v6.4.0",
         "symfony/notifier": "v5.3.8",
         "symfony/symfony": "*",


### PR DESCRIPTION
Change the constraint to match the 6.6.0.0 branch.

Restrict the core version via conflict constraint