### PR TITLE
fix: restrict opensearch-project/opensearch-php

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,6 +14,7 @@
         "symfony/cache": "6.2.3 || 5.4.17",
         "symfony/messenger": "6.3.5",
         "zircote/swagger-php": "4.8.7",
-        "symfony/phpunit-bridge": "6.4.8 || 7.0.8"
+        "symfony/phpunit-bridge": "6.4.8 || 7.0.8",
+        "opensearch-project/opensearch-php": ">2.3.1"
     }
 }


### PR DESCRIPTION
The new version causes many issues with our integration tests. We don't yet know the root cause, but we'll add this for now as a temporary fix