### PR TITLE
fix: Remove packages, that should not be relevant anymore

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -8,14 +8,8 @@
     },
     "conflict": {
         "phenx/php-font-lib": "<0.5.5",
-        "symfony/var-exporter": "v6.3.9 || v6.4.0",
-        "symfony/notifier": "v5.3.8",
         "symfony/symfony": "*",
-        "symfony/cache": "6.2.3 || 5.4.17",
-        "symfony/messenger": "6.3.5",
-        "symfony/framework-bundle": "6.4.19 || 7.2.4",
         "zircote/swagger-php": "4.8.7",
-        "symfony/phpunit-bridge": "6.4.8 || 7.0.8",
         "opensearch-project/opensearch-php": ">2.3.1",
         "shopware/k8s-meta": "<=1.0.3"
     }


### PR DESCRIPTION
I removed all Symfony packages lower than 7.x because Shopware 6.6 already uses Symfony 7.2
So I don't see a reason why we still need them. Please correct me, if I am wrong