### PR TITLE
fix: Remove twig conflicts

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -9,9 +9,6 @@
     "conflict": {
         "phenx/php-font-lib": "<0.5.5",
         "shopware/core": "<6.5",
-        "twig/twig": ">=3.9.0",
-        "twig/intl-extra": ">=3.9.0",
-        "squirrelphp/twig-php-syntax": "~1.8",
         "symfony/var-exporter": "v6.3.9 || v6.4.0",
         "symfony/notifier": "v5.3.8",
         "symfony/symfony": "*",

--- a/composer.json
+++ b/composer.json
@@ -4,11 +4,10 @@
     "description": "Shopware 6 conflicting packages",
     "license": "MIT",
     "require": {
-        "shopware/core": "*"
+        "shopware/core": ">6.5.8.16 <6.6"
     },
     "conflict": {
         "phenx/php-font-lib": "<0.5.5",
-        "shopware/core": "<6.5",
         "symfony/var-exporter": "v6.3.9 || v6.4.0",
         "symfony/notifier": "v5.3.8",
         "symfony/symfony": "*",


### PR DESCRIPTION
Enable twig updates again for SW 6.5. counterpart: https://github.com/shopware/shopware/pull/7306