### PR TITLE
feat: Conflict with older symfony/type-info versions which are not compatible with phpstan 2

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -9,6 +9,7 @@
     "conflict": {
         "phenx/php-font-lib": "<0.5.5",
         "symfony/symfony": "*",
+        "symfony/type-info": "<7.1.8",
         "zircote/swagger-php": "4.8.7",
         "opensearch-project/opensearch-php": ">2.3.1",
         "shopware/k8s-meta": "<=1.0.3"


### PR DESCRIPTION
See https://github.com/FriendsOfShopware/platform-plugin-dev-docker/actions/runs/13936156525/job/39004640133?pr=41#step:5:1242

And this comment: https://github.com/FriendsOfShopware/platform-plugin-dev-docker/pull/41#issuecomment-2736899279

When I add the conflict to the `composer.json` everything works as expected: https://github.com/FriendsOfShopware/platform-plugin-dev-docker/actions/runs/13950779471/job/39049495464?pr=41#step:5:554

But tbh I am not sure against which branch this PR should be targeted, as in the current trunk (version 6.7) the package in version 0.5.0 is required: https://github.com/shopware/shopware/blob/trunk/composer.json#L114