### PR TITLE
feat: Allow twig updates again

### DIFF
--- a/composer.0.5.1.json
+++ b/composer.0.5.1.json
@@ -4,7 +4,7 @@
   "description": "Shopware 6 conflicting packages",
   "license": "MIT",
   "require": {
-    "shopware/core": ">=6.7.1.0"
+    "shopware/core": ">=6.6.10.7 <6.7.0.0 || >=6.7.1.0"
   },
   "conflict": {
     "phenx/php-font-lib": "<0.5.5",


### PR DESCRIPTION
needed for allowing twig update in 6.6 again, which is needed for Symfony 7.3 update

relates to https://github.com/shopware/shopware/issues/10995