### PR TITLE
fix: add framework-bundle conflict to all versions

### DIFF
--- a/composer.0.0.1.json
+++ b/composer.0.0.1.json
@@ -8,6 +8,7 @@
     },
     "conflict": {
         "symfony/notifier": "v5.3.8",
-        "symfony/symfony": "*"
+        "symfony/symfony": "*",
+        "symfony/framework-bundle": ">= 6.4.19 < 7.0 || >=7.2.4"
     }
 }

--- a/composer.0.0.2.json
+++ b/composer.0.0.2.json
@@ -9,6 +9,7 @@
     "conflict": {
         "symfony/notifier": "v5.3.8",
         "symfony/symfony": "*",
-        "symfony/cache": "6.2.3 || 5.4.17"
+        "symfony/cache": "6.2.3 || 5.4.17",
+        "symfony/framework-bundle": ">= 6.4.19 < 7.0 || >=7.2.4"
     }
 }

--- a/composer.0.1.0.json
+++ b/composer.0.1.0.json
@@ -10,6 +10,7 @@
     "conflict": {
         "symfony/notifier": "v5.3.8",
         "symfony/symfony": "*",
-        "symfony/cache": "6.2.3 || 5.4.17"
+        "symfony/cache": "6.2.3 || 5.4.17",
+        "symfony/framework-bundle": ">= 6.4.19 < 7.0 || >=7.2.4"
     }
 }

--- a/composer.0.1.1.json
+++ b/composer.0.1.1.json
@@ -11,6 +11,7 @@
         "symfony/notifier": "v5.3.8",
         "symfony/symfony": "*",
         "symfony/cache": "6.2.3 || 5.4.17",
-        "symfony/messenger": "6.3.5"
+        "symfony/messenger": "6.3.5",
+        "symfony/framework-bundle": ">= 6.4.19 < 7.0 || >=7.2.4"
     }
 }

--- a/composer.0.1.2.json
+++ b/composer.0.1.2.json
@@ -11,6 +11,7 @@
         "symfony/notifier": "v5.3.8",
         "symfony/symfony": "*",
         "symfony/cache": "6.2.3 || 5.4.17",
-        "symfony/messenger": "6.3.5"
+        "symfony/messenger": "6.3.5",
+        "symfony/framework-bundle": ">= 6.4.19 < 7.0 || >=7.2.4",
     }
 }

--- a/composer.0.1.3.json
+++ b/composer.0.1.3.json
@@ -11,6 +11,7 @@
         "symfony/notifier": "v5.3.8",
         "symfony/symfony": "*",
         "symfony/cache": "6.2.3 || 5.4.17",
+        "symfony/framework-bundle": ">= 6.4.19 < 7.0 || >=7.2.4",
         "symfony/messenger": "6.3.5"
     }
 }

--- a/composer.0.1.4.json
+++ b/composer.0.1.4.json
@@ -12,6 +12,7 @@
         "symfony/symfony": "*",
         "symfony/cache": "6.2.3 || 5.4.17",
         "symfony/messenger": "6.3.5",
+        "symfony/framework-bundle": ">= 6.4.19 < 7.0 || >=7.2.4",
         "zircote/swagger-php": "4.8.7"
     }
 }

--- a/composer.0.1.5.json
+++ b/composer.0.1.5.json
@@ -13,6 +13,7 @@
         "symfony/symfony": "*",
         "symfony/cache": "6.2.3 || 5.4.17",
         "symfony/messenger": "6.3.5",
+        "symfony/framework-bundle": ">= 6.4.19 < 7.0 || >=7.2.4",
         "zircote/swagger-php": "4.8.7"
     }
 }

--- a/composer.0.1.6.json
+++ b/composer.0.1.6.json
@@ -14,6 +14,7 @@
         "symfony/symfony": "*",
         "symfony/cache": "6.2.3 || 5.4.17",
         "symfony/messenger": "6.3.5",
+        "symfony/framework-bundle": ">= 6.4.19 < 7.0 || >=7.2.4",
         "zircote/swagger-php": "4.8.7"
     }
 }

--- a/composer.0.1.7.json
+++ b/composer.0.1.7.json
@@ -15,6 +15,7 @@
         "symfony/symfony": "*",
         "symfony/cache": "6.2.3 || 5.4.17",
         "symfony/messenger": "6.3.5",
+        "symfony/framework-bundle": ">= 6.4.19 < 7.0 || >=7.2.4",
         "zircote/swagger-php": "4.8.7"
     }
 }

--- a/composer.0.1.8.json
+++ b/composer.0.1.8.json
@@ -16,6 +16,7 @@
         "symfony/symfony": "*",
         "symfony/cache": "6.2.3 || 5.4.17",
         "symfony/messenger": "6.3.5",
+        "symfony/framework-bundle": ">= 6.4.19 < 7.0 || >=7.2.4",
         "zircote/swagger-php": "4.8.7"
     }
 }

--- a/composer.0.1.9.json
+++ b/composer.0.1.9.json
@@ -16,6 +16,7 @@
         "symfony/symfony": "*",
         "symfony/cache": "6.2.3 || 5.4.17",
         "symfony/messenger": "6.3.5",
+        "symfony/framework-bundle": ">= 6.4.19 < 7.0 || >=7.2.4",
         "zircote/swagger-php": "4.8.7"
     }
 }


### PR DESCRIPTION
In older versions we didn't required a min conflict version. Composer picks an older conflict version rather adding a conflict