### PR TITLE
chore: remove opensearch conflict for dependency update

### DIFF
--- a/composer.0.6.1.json
+++ b/composer.0.6.1.json
@@ -1,0 +1,16 @@
+{
+  "name": "shopware/conflicts",
+  "type": "metapackage",
+  "description": "Shopware 6 conflicting packages",
+  "license": "MIT",
+  "require": {
+    "shopware/core": ">=6.7.11.0"
+  },
+  "conflict": {
+    "phenx/php-font-lib": "<0.5.5",
+    "symfony/symfony": "*",
+    "symfony/web-profiler-bundle": "<7.3.0",
+    "zircote/swagger-php": "4.8.7",
+    "shopware/k8s-meta": "<=1.0.3"
+  }
+}


### PR DESCRIPTION
OpensearchClient conflict was dropped as we plan to update the client library here: https://github.com/shopware/shopware/pull/15832