### PR TITLE
chore: conflict Twig 3.28 for Shopware 6.7

### DIFF
--- a/composer.0.5.1.json
+++ b/composer.0.5.1.json
@@ -12,6 +12,7 @@
     "zircote/swagger-php": "4.8.7",
     "opensearch-project/opensearch-php": ">2.3.1",
     "shopware/k8s-meta": "<=1.0.3",
-    "doctrine/dbal": ">=4.3.0"
+    "doctrine/dbal": ">=4.3.0",
+    "twig/twig": ">=3.28"
   }
 }

--- a/composer.0.6.0.json
+++ b/composer.0.6.0.json
@@ -13,6 +13,7 @@
     "symfony/polyfill-php84": "1.38.0",
     "zircote/swagger-php": "4.8.7",
     "opensearch-project/opensearch-php": ">2.3.1",
-    "shopware/k8s-meta": "<=1.0.3"
+    "shopware/k8s-meta": "<=1.0.3",
+    "twig/twig": ">=3.28"
   }
 }

--- a/composer.0.6.1.json
+++ b/composer.0.6.1.json
@@ -12,6 +12,7 @@
     "symfony/web-profiler-bundle": "<7.3.0",
     "symfony/polyfill-php84": "1.38.0",
     "zircote/swagger-php": "4.8.7",
-    "shopware/k8s-meta": "<=1.0.3"
+    "shopware/k8s-meta": "<=1.0.3",
+    "twig/twig": ">=3.28"
   }
 }


### PR DESCRIPTION
Twig 3.28.0 changed `CoreExtension::include()` to return `Twig\Markup`. The `sw_include` wrapper in Shopware 6.7 declares `: string` and now throws a `TypeError` on render. This breaks the storefront and the administration login on any fresh install or dependency update of released 6.7 versions.

Fixed for the next release in shopware/shopware#18027. 6.7.0.x is already protected by the existing `twig/twig >=3.21` conflict in 0.5.0. The 0.5.1 entry also caps 6.6.10.8+, which loses nothing from staying on Twig 3.27.

CI evidence: shopware/shopware acceptance-update jobs against v6.7.11.1 fail since the Twig release (https://github.com/shopware/shopware/actions/runs/28688073396/job/85084302078).
